### PR TITLE
Implement Entity Instance Reload on Exception

### DIFF
--- a/EntityFrameworkCore.BootKit/DatabaseExtensions/TransactionDatabaseExtension.cs
+++ b/EntityFrameworkCore.BootKit/DatabaseExtensions/TransactionDatabaseExtension.cs
@@ -78,8 +78,8 @@ namespace EntityFrameworkCore.BootKit
                     }
                     catch (Exception ex)
                     {
-                        ReloadChangedEntities(dbContext);
                         transaction.Rollback();
+                        ReloadChangedEntities(dbContext);
                         if (ex.Message.Contains("See the inner exception for details"))
                             throw ex.InnerException;
                         else
@@ -98,8 +98,8 @@ namespace EntityFrameworkCore.BootKit
                 {
                     if (masterDb.CurrentTransaction != null)
                     {
-                        ReloadChangedEntities(dbContext);
                         masterDb.CurrentTransaction.Rollback();
+                        ReloadChangedEntities(dbContext);
                     }
                     if (ex.Message.Contains("See the inner exception for details"))
                         throw ex.InnerException;


### PR DESCRIPTION
When using EntityFrameworkCore.BootKit to perform database operations, if an exception is caught, the entity instance still retains the invalid changes that violate database constraints (e.g., exceeding length limits, unsupported encoding characters). This causes all subsequent database operations on the same entity instance within the same lifecycle to fail.